### PR TITLE
Explicit version of gulp-nunjucks-render at 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-if": "latest",
     "gulp-imagemin": "latest",
     "gulp-notify": "latest",
-    "gulp-nunjucks-render": "latest",
+    "gulp-nunjucks-render": "2.0.0",
     "gulp-pixrem": "latest",
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "latest",


### PR DESCRIPTION
Nunjucks v2.1.0 breaks the build.